### PR TITLE
Arreglar renderizado de corchetes y encabezados en el Asistente IA

### DIFF
--- a/client/src/components/AIAssistant.tsx
+++ b/client/src/components/AIAssistant.tsx
@@ -1,8 +1,9 @@
 import React, { useState, useRef, useEffect } from 'react';
-import { Send, PaperclipIcon, Brain } from 'lucide-react';
+import { Send, Brain } from 'lucide-react';
 import { consultarAsistenteIA } from '@/lib/openai';
 import { useFlashcards } from '@/context/FlashcardContext';
 import { Flashcard } from '@/data/flashcards';
+import ReactMarkdown from 'react-markdown';
 
 // Definir la estructura de un mensaje
 interface Mensaje {
@@ -332,13 +333,19 @@ const AIAssistant: React.FC = () => {
                       : 'bg-white dark:bg-slate-700 text-slate-800 dark:text-white border border-slate-200 dark:border-slate-600'
               }`}
             >
-              <div className="mb-1">
-                {mensaje.contenido.split('\n').map((line, i) => (
-                  <span key={i} className="block">
-                    {line}
-                    {i < mensaje.contenido.split('\n').length - 1 && <br />}
-                  </span>
-                ))}
+              <div className="mb-1 markdown-content">
+                {mensaje.tipo === 'asistente' ? (
+                  <ReactMarkdown className="prose prose-sm dark:prose-invert max-w-none">
+                    {mensaje.contenido}
+                  </ReactMarkdown>
+                ) : (
+                  mensaje.contenido.split('\n').map((line, i) => (
+                    <span key={i} className="block">
+                      {line}
+                      {i < mensaje.contenido.split('\n').length - 1 && <br />}
+                    </span>
+                  ))
+                )}
               </div>
               <div className="text-xs opacity-70 text-right">
                 {formatearHora(mensaje.timestamp)}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -250,3 +250,116 @@
   background-color: rgba(0, 116, 149, 0.2); /* #007495 with 0.2 opacity */
 }
 
+/* Estilos para el contenido markdown en mensajes */
+.markdown-content h1 {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin-top: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+.markdown-content h2 {
+  font-size: 1.3rem;
+  font-weight: 600;
+  margin-top: 0.8rem;
+  margin-bottom: 0.4rem;
+}
+
+.markdown-content h3 {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin-top: 0.6rem;
+  margin-bottom: 0.3rem;
+}
+
+.markdown-content p {
+  margin-bottom: 0.6rem;
+}
+
+.markdown-content ul, .markdown-content ol {
+  margin-left: 1.5rem;
+  margin-bottom: 0.6rem;
+}
+
+.markdown-content li {
+  margin-bottom: 0.2rem;
+}
+
+.markdown-content code {
+  background-color: rgba(0, 0, 0, 0.06);
+  border-radius: 0.2rem;
+  padding: 0.1rem 0.3rem;
+  font-family: monospace;
+}
+
+.dark .markdown-content code {
+  background-color: rgba(255, 255, 255, 0.1);
+}
+
+/* Estilos para los corchetes de markdown que deben mostrarse como checkbox */
+.markdown-content input[type="checkbox"] {
+  margin-right: 0.4rem;
+}
+
+.prose :where(h1, h2, h3, h4) {
+  color: inherit;
+  font-weight: 700;
+  margin-top: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+.prose :where(h1) {
+  font-size: 1.5rem;
+}
+
+.prose :where(h2) {
+  font-size: 1.3rem;
+}
+
+.prose :where(h3) {
+  font-size: 1.1rem;
+}
+
+.prose :where(p) {
+  margin-top: 0.3rem;
+  margin-bottom: 0.3rem;
+}
+
+.prose :where(ul, ol) {
+  padding-left: 1.3rem;
+  margin-top: 0.3rem;
+  margin-bottom: 0.3rem;
+}
+
+.prose :where(li) {
+  margin-top: 0.15rem;
+  margin-bottom: 0.15rem;
+}
+
+/* Estilo específico para los elementos de task list en markdown */
+.prose ul li input[type="checkbox"] {
+  margin-right: 0.5rem;
+}
+
+/* Para asegurarnos de que los encabezados ### se muestren correctamente */
+.prose h3::before {
+  content: "";
+  display: block;
+  height: 0.5rem;
+}
+
+/* Estilo específico para los elementos de markdown en modo oscuro */
+.dark .prose {
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.dark .prose strong {
+  color: white;
+}
+
+.dark .prose code {
+  color: rgba(255, 255, 255, 0.8);
+  background-color: rgba(255, 255, 255, 0.1);
+  border-radius: 0.2rem;
+  padding: 0.1rem 0.3rem;
+}

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.55.0",
     "react-icons": "^5.4.0",
+    "react-markdown": "^9.0.1",
     "react-resizable-panels": "^2.1.7",
     "recharts": "^2.15.2",
     "tailwind-merge": "^2.6.0",


### PR DESCRIPTION
## Solución para problema de renderizado de markdown

Este PR soluciona el problema de visualización de corchetes (`[ ]`) y marcadores de encabezado (`###`) en los mensajes del asistente de IA.

### Cambios realizados:

1. **Añadido React-Markdown:** Se ha instalado la biblioteca `react-markdown` para procesar correctamente el contenido markdown en las respuestas del asistente.

2. **Modificado AIAssistant.tsx:** Se ha reemplazado el renderizado simple de texto por el componente ReactMarkdown, lo que permite visualizar correctamente elementos markdown como:
   - Corchetes `[ ]` que ahora se mostrarán como casillas de verificación
   - Encabezados `###` que ahora se mostrarán como títulos
   - Listas ordenadas y no ordenadas
   - Texto formateado con negritas, cursivas, etc.

3. **Actualizados estilos CSS:** Se han añadido reglas específicas para estilizar correctamente los elementos markdown en el contexto de los mensajes del chat, tanto en modo claro como oscuro.

### Cómo probar los cambios:

1. Inicia una conversación con el asistente
2. Pide información que contenga listas con casillas de verificación o encabezados
3. Verifica que los elementos se muestran correctamente formateados

Esta mejora hace que el asistente sea más útil ya que la información que proporciona se mostrará de forma estructurada y fácil de leer.