### PR TITLE
Eliminar marcadores no deseados y mejorar renderizado markdown

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -250,3 +250,132 @@
   background-color: rgba(0, 116, 149, 0.2); /* #007495 with 0.2 opacity */
 }
 
+/* Estilos para el contenido markdown en mensajes */
+.markdown-content h1 {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin-top: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+.markdown-content h2 {
+  font-size: 1.3rem;
+  font-weight: 600;
+  margin-top: 0.8rem;
+  margin-bottom: 0.4rem;
+}
+
+.markdown-content h3 {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin-top: 0.6rem;
+  margin-bottom: 0.3rem;
+}
+
+.markdown-content p {
+  margin-bottom: 0.6rem;
+}
+
+.markdown-content ul, .markdown-content ol {
+  margin-left: 1.5rem;
+  margin-bottom: 0.6rem;
+}
+
+.markdown-content li {
+  margin-bottom: 0.2rem;
+}
+
+.markdown-content code {
+  background-color: rgba(0, 0, 0, 0.06);
+  border-radius: 0.2rem;
+  padding: 0.1rem 0.3rem;
+  font-family: monospace;
+}
+
+.dark .markdown-content code {
+  background-color: rgba(255, 255, 255, 0.1);
+}
+
+/* Estilos para los corchetes de markdown que deben mostrarse como checkbox */
+.markdown-content input[type="checkbox"] {
+  margin-right: 0.4rem;
+}
+
+/* Estilos para los elementos específicos de Prose */
+.prose {
+  max-width: 100%;
+}
+
+.prose :where(h1, h2, h3, h4) {
+  color: inherit;
+  font-weight: 700;
+  margin-top: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+.prose :where(h1) {
+  font-size: 1.5rem;
+}
+
+.prose :where(h2) {
+  font-size: 1.3rem;
+}
+
+.prose :where(h3) {
+  font-size: 1.1rem;
+}
+
+.prose :where(p) {
+  margin-top: 0.3rem;
+  margin-bottom: 0.6rem;
+}
+
+.prose :where(ul, ol) {
+  padding-left: 1.3rem;
+  margin-top: 0.3rem;
+  margin-bottom: 0.6rem;
+}
+
+.prose :where(li) {
+  margin-top: 0.15rem;
+  margin-bottom: 0.15rem;
+}
+
+.prose :where(strong) {
+  font-weight: 700;
+}
+
+.prose :where(em) {
+  font-style: italic;
+}
+
+/* Estilos especiales para elementos específicos que podrían aparecer en el texto */
+.prose :where(pre) {
+  background-color: rgba(0, 0, 0, 0.05);
+  border-radius: 0.25rem;
+  padding: 0.75rem;
+  overflow-x: auto;
+  margin: 0.5rem 0;
+}
+
+.dark .prose :where(pre) {
+  background-color: rgba(255, 255, 255, 0.1);
+}
+
+/* Eliminar estilos de marcadores de referencia */
+.prose :where(a[href^="#source"]) {
+  display: none !important;
+}
+
+/* Eliminar cualquier texto o elementos con el formato de referencias como [4:0†source] */
+.prose *:not(pre) > [data-source],
+.prose *:not(pre) > [data-reference],
+.prose *:not(pre) > span[class*="source"],
+.prose *:not(pre) > span[class*="reference"] {
+  display: none !important;
+}
+
+/* Para lidiar con los asteriscos dobles que marcan texto en negrita */
+.prose strong {
+  font-weight: 700;
+}

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.55.0",
     "react-icons": "^5.4.0",
+    "react-markdown": "^9.0.1",
     "react-resizable-panels": "^2.1.7",
     "recharts": "^2.15.2",
     "tailwind-merge": "^2.6.0",


### PR DESCRIPTION
## Solución para eliminar marcadores no deseados y mejorar renderizado markdown

Este PR soluciona el problema de visualización de marcadores no deseados como `【4:0†source】` y mejora el renderizado de elementos markdown en los mensajes del asistente de IA.

### Cambios realizados:

1. **Mejora en el procesamiento de texto**: Se ha añadido una función `limpiarTextoMarkdown` que elimina los marcadores de referencia no deseados y asegura que los caracteres especiales markdown se muestren correctamente.

2. **Modificaciones en AIAssistant.tsx**: Se procesa el texto de respuesta para eliminar patrones como `【4:0†source】`, `[4:0†source]` y otros similares antes de mostrarlo al usuario.

3. **Estilos CSS mejorados**: Se han añadido reglas específicas para:
   - Ocultar explícitamente marcadores de referencia en el texto renderizado
   - Mejorar la apariencia de los encabezados, listas y otros elementos markdown
   - Asegurar que los elementos destacados con `**` se muestren correctamente en negrita

### Cómo probar los cambios:

1. Envía una consulta específica al asistente, como "Crea una metáfora o analogía para Estafilococo dorado"
2. Verifica que no aparezcan marcadores como `【4:0†source】` en la respuesta
3. Comprueba que los encabezados y elementos destacados se muestren correctamente formateados

Este PR complementa el PR anterior (#1) que implementó ReactMarkdown, agregando una capa adicional de limpieza para manejar los marcadores específicos que genera el asistente.